### PR TITLE
Bug fix in GetMemoryMap() of gnu-efi/bootloader/main.c

### DIFF
--- a/gnu-efi/bootloader/main.c
+++ b/gnu-efi/bootloader/main.c
@@ -232,8 +232,15 @@ EFI_STATUS efi_main (EFI_HANDLE ImageHandle, EFI_SYSTEM_TABLE *SystemTable) {
 	{
 		
 		SystemTable->BootServices->GetMemoryMap(&MapSize, Map, &MapKey, &DescriptorSize, &DescriptorVersion);
-		SystemTable->BootServices->AllocatePool(EfiLoaderData, MapSize, (void**)&Map);
-		SystemTable->BootServices->GetMemoryMap(&MapSize, Map, &MapKey, &DescriptorSize, &DescriptorVersion);
+        while (1) {
+            SystemTable->BootServices->AllocatePool(EfiLoaderData, MapSize, (void**) &Map);
+            EFI_STATUS status = SystemTable->BootServices->GetMemoryMap(&MapSize, Map, &MapKey, &DescriptorSize, &DescriptorVersion);
+            if (status == EFI_SUCCESS){
+                break;
+            }else{
+                SystemTable->BootServices->FreePool(Map);
+            }
+        }
 
 	}
 


### PR DESCRIPTION
In boot loader, after GetMemoryMap(), we need to check if it is successful. Because AllocatePool() might change the MapSize. So, we need to loop to getMemroyMap() repeatedly util it is successful.