### PR TITLE
Fixed RSPD finder in Bootloader

### DIFF
--- a/gnu-efi/bootloader/main.c
+++ b/gnu-efi/bootloader/main.c
@@ -242,10 +242,10 @@ EFI_STATUS efi_main (EFI_HANDLE ImageHandle, EFI_SYSTEM_TABLE *SystemTable) {
 	EFI_GUID Acpi2TableGuid = ACPI_20_TABLE_GUID;
 
 	for (UINTN index = 0; index < SystemTable->NumberOfTableEntries; index++){
-		if (CompareGuid(&configTable[index].VendorGuid, &Acpi2TableGuid)){
-			if (strcmp((CHAR8*)"RSD PTR ", (CHAR8*)configTable->VendorTable, 8)){
-				rsdp = (void*)configTable->VendorTable;
-				//break;
+		if (!CompareGuid(&(SystemTable->ConfigurationTable[index].VendorGuid), &Acpi2TableGuid)){
+			if (strcmp((CHAR8*)"RSD PTR ", (CHAR8*)(configTable->VendorTable), 8)){
+				rsdp = (void*)(configTable->VendorTable);
+				break;
 			}
 		}
 		configTable++;


### PR DESCRIPTION
This method for obtaining the RSDP from the UEFI system table was vague and had some potential for unexpected behavior outside of QEMU. After looking into this some more, I found [this blog post from 2015](https://blog.fpmurphy.com/2015/01/list-acpi-tables-from-uefi-shell.html) with a very similar method of obtaining the UEFI. I attempted to refactor the code in main.c to make it look more like the example from the blog post but encountered several unexpected General Protection Faults. After an extended period of time debugging, I discovered the source of the strange behavior, as well as why the seemingly obvious place for a break statement on line 248 in main.c was causing the bootloader to find the wrong RSDP.

As it turns out, both the blog post and this bootloader incorrectly used the CompareGuid function from gnu-efi. According to the [source file](https://github.com/vathpela/gnu-efi/blob/master/lib/guid.c), CompareGuid returns 0 if its arguments are equivalent. This appears to have gone unnoticed by the original blog author and likely resulted in the same incorrect code showing up here as well. This means that line 245 in main.c actually does the opposite of its intended purpose, resulting in the if statement only evaluating to true if the VendorGuid is not the ACPI 2.0 Table GUID. This appears to have been an extremely unlucky series of events, as the specific way this was implemented in the blog post resulted in seemingly correct behavior, but when slightly modified can cause serious issues. In fact, the only reason the bootloader successfully found the RSPD2 is because line 245 was checking the incorrect Vendor GUID, and the ACPI 2 table was stored after the ACPI 1 table in memory on QEMU. 

Overall, this resulted in a lurking possible error that will probably resurface if anyone attempts to run this on hardware that stores the ACPI 2 table before the ACPI table in memory. This error can be easily remedied by instead checking that CompareGuid returns 0 and using SystemTable->ConfigurationTable instead of configTable on line 245. Not only will this fix the potential for returning the wrong RSDP, which will likely cause a GP fault when attempting to deference the XSDT address. This also enables us to add back the break statement on line 248, which may improve performance.
