### PR TITLE
Updated Bitmap.cpp to make it slightly better AFAIK

### DIFF
--- a/kernel/src/Bitmap.cpp
+++ b/kernel/src/Bitmap.cpp
@@ -2,7 +2,7 @@
 
 bool Bitmap::operator[](uint64_t index){
     uint64_t byteIndex = index / 8;
-    uint8_t bitIndex = index % 8;
+    uint8_t bitIndex = index & 0b111;
     uint8_t bitIndexer = 0b10000000 >> bitIndex;
     if ((Buffer[byteIndex] & bitIndexer) > 0){
         return true;
@@ -12,7 +12,7 @@ bool Bitmap::operator[](uint64_t index){
 
 void Bitmap::Set(uint64_t index, bool value){
     uint64_t byteIndex = index / 8;
-    uint8_t bitIndex = index % 8;
+    uint8_t bitIndex = index & 0b111;
     uint8_t bitIndexer = 0b10000000 >> bitIndex;
     Buffer[byteIndex] &= ~bitIndexer;
     if (value){


### PR DESCRIPTION
AFAIK the modulo operator is typically less efficient than using the & operator, although the & operator is less versatile for this purpose, but it can be used in this situation.